### PR TITLE
docs: improve description of availability

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 e2e/
-venv/
 Dockerfile
 README.md
 validator-elector

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # validator-elector
 
-validator-elector helps run a highly available [Celo
+validator-elector helps run a [Celo
 validator](https://docs.celo.org/getting-started/mainnet/running-a-validator-in-mainnet)
-on Kubernetes.
+on Kubernetes with automatic failover. You can use validator-elector
+to increase availability or enable rolling deployments.
 
 ## Usage
 


### PR DESCRIPTION
"automatic failover" instead of "highly available"